### PR TITLE
Fix/render

### DIFF
--- a/backend/config/socket.js
+++ b/backend/config/socket.js
@@ -7,11 +7,11 @@ const FRONTEND_DEV_URL = process.env.FRONTEND_DEV_URL;
 export const configureSocket = (server) => {
   const io = new Server(server, {
     cors: {
-      origin: FRONTEND_URL || FRONTEND_DEV_URL,
+      origin: [FRONTEND_URL, FRONTEND_DEV_URL, "http://localhost:5173"],
       methods: ["GET", "POST", "PUT", "DELETE"],
       credentials: true,
     },
-    transports: ["websocket"],
+    transports: ["websocket", "polling"],
   });
   console.log("Socket is running!");
   

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -134,8 +134,8 @@ export async function loginUser(req, res) {
       .status(200)
       .cookie("jwt", token, {
         httpOnly: false,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "none",
+        secure: process.env.NODE_ENV === "production", // Nur im Produktivmodus aktivieren
+        sameSite: process.env.NODE_ENV === "production" ? "none" : "lax", // "lax" für localhost-Entwicklung
         maxAge: AUTH_CONFIG.COOKIE_MAX_AGE,
       })
       .json({ msg: "Login successful", user });

--- a/backend/middleware/jwt.js
+++ b/backend/middleware/jwt.js
@@ -67,8 +67,8 @@ export const authenticate = async (req, res, next) => {
       const newToken = generateToken({ userId: user._id });
       res.cookie("jwt", newToken, {
         httpOnly: false,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "none",
+        secure: process.env.NODE_ENV === "production", // Nur im Produktivmodus aktivieren
+        sameSite: process.env.NODE_ENV === "production" ? "none" : "lax", // "lax" für localhost-Entwicklung
         maxAge: COOKIE_MAX_AGE,
       });
     }
@@ -83,7 +83,7 @@ export const authenticate = async (req, res, next) => {
 
 export const authenticateSocket = async (socket, next) => {
   console.log("Authenticating...");
-  
+
   try {
     const token = socket.handshake.auth.token;
 
@@ -111,13 +111,12 @@ export const authenticateSocket = async (socket, next) => {
 
     if (tokenExp - Date.now() < fiveMinutes) {
       const newToken = generateToken({ userId: user._id });
-      
-      socket.emit("tokenRenewal", {token: newToken})
+
+      socket.emit("tokenRenewal", { token: newToken });
     }
 
     socket.user = { id: user._id, role: user.role };
     next();
-    
   } catch (error) {
     console.error("Authentication error:", error);
     next(new Error("Authentication failed"));

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,7 +28,7 @@ app.use(cookieParser());
 
 app.use(
   cors({
-    origin: [FRONT_END], // Frontend-URL
+    origin: [FRONT_END, "http://localhost:5173"], // Frontend-URL
     credentials: true, // Allows sending Cookies
   })
 );

--- a/frontend/src/api/userApi.js
+++ b/frontend/src/api/userApi.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
+const checkENV = import.meta.env.VITE_NODE_ENV === "production";
+const BASE_URL = checkENV ? import.meta.env.VITE_API_BASE_URL : import.meta.env.VITE_API_DEV_URL;
 
 export const registerApi = async (username, email, password, birthdate) => {
   try {

--- a/frontend/src/api/userApi.js
+++ b/frontend/src/api/userApi.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const checkENV = import.meta.env.VITE_NODE_ENV === "production";
+const checkENV = import.meta.env.VITE_API_NODE_ENV === "production";
 const BASE_URL = checkENV ? import.meta.env.VITE_API_BASE_URL : import.meta.env.VITE_API_DEV_URL;
 
 export const registerApi = async (username, email, password, birthdate) => {

--- a/frontend/src/components/KonvaCanvas/KonvaCanvas.jsx
+++ b/frontend/src/components/KonvaCanvas/KonvaCanvas.jsx
@@ -12,13 +12,16 @@ const KonvaCanvas = ({ isInteractive }) => {
   const colorRef = useRef(selectedColor);
 
   const socketRef = useRef(null);
+  
+  const checkENV = import.meta.env.VITE_API_NODE_ENV === "production";
+  const URL = checkENV ? import.meta.env.VITE_API_BASE_URL : import.meta.env.VITE_API_DEV_URL
 
   useEffect(() => {
     colorRef.current = selectedColor;
   }, [selectedColor]);
 
   useEffect(() => {
-    socketRef.current = io(import.meta.env.VITE_API_BASE_URL);
+    socketRef.current = io(URL);
 
     const stage = new Konva.Stage({
       container: "konva-container",

--- a/frontend/src/components/LoginOverlay/LoginOverlay.jsx
+++ b/frontend/src/components/LoginOverlay/LoginOverlay.jsx
@@ -13,7 +13,8 @@ const LoginOverlay = ({ isOpen, onClose, onLogin }) => {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
 
-  const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+  const checkENV = import.meta.env.VITE_API_NODE_ENV === "production";
+  const BASE_URL = checkENV ? import.meta.env.VITE_API_BASE_URL : import.meta.env.VITE_API_DEV_URL;
 
   const handleLogin = async () => {
     if (!username || !password) {

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -2,7 +2,7 @@ import { io } from "socket.io-client";
 
 const checkENV = import.meta.env.VITE_API_NODE_ENV === "production"
 
-const SOCKET_URL = checkENV ? import.meta.env.VITE_BASE_URL : import.meta.env.VITE_API_DEV_URL
+const SOCKET_URL = checkENV ? import.meta.env.VITE_API_BASE_URL : import.meta.env.VITE_API_DEV_URL
 
 const socket = io(SOCKET_URL, {
   autoConnect: false,

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -1,6 +1,8 @@
 import { io } from "socket.io-client";
 
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || import.meta.env.VITE_API_BASE_URL;
+const checkENV = import.meta.env.VITE_API_NODE_ENV === "production"
+
+const SOCKET_URL = checkENV ? import.meta.env.VITE_BASE_URL : import.meta.env.VITE_API_DEV_URL
 
 const socket = io(SOCKET_URL, {
   autoConnect: false,

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -9,6 +9,7 @@ const socket = io(SOCKET_URL, {
   reconnection: true,
   reconnectionAttempts: 5,
   reconnectionDelay: 1000,
+  transports: ["websocket", "polling"]
 });
 
 socket.on("connection_error", (err) => {

--- a/frontend/src/stores/useCanvasStore.js
+++ b/frontend/src/stores/useCanvasStore.js
@@ -2,6 +2,9 @@ import { create } from "zustand";
 import { useEffect } from "react";
 import { io } from "socket.io-client";
 
+const checkENV = import.meta.env.VITE_API_NODE_ENV === "production";
+const URL = checkENV ? import.meta.env.VITE_API_BASE_URL : import.meta.env.VITE_API_DEV_URL
+
 export const useCanvasStore = create((set, get) => ({
   socket: null,
   selectedColor: "#000000",
@@ -9,7 +12,7 @@ export const useCanvasStore = create((set, get) => ({
   setSelectedColor: (color) => set({ selectedColor: color }),
 
   initializeSocket: () => {
-    const newSocket = io(import.meta.env.VITE_API_BASE_URL);
+    const newSocket = io(URL);
     set({ socket: newSocket });
     console.log("Socket.IO verbunden");
 


### PR DESCRIPTION
rewrote res.cookie into: secure: process.env.NODE_ENV === "production", // Nur im Produktivmodus aktivieren
        sameSite: process.env.NODE_ENV === "production" ? "none" : "lax", // "lax" für localhost-Entwicklung